### PR TITLE
Add support for results in ERB files

### DIFF
--- a/lib/jiminy/recording/n_plus_one.rb
+++ b/lib/jiminy/recording/n_plus_one.rb
@@ -5,7 +5,7 @@ module Jiminy
     class NPlusOne
       attr_reader :file, :location
 
-      LOCATION_REGEXP = /^(?<file>[\w_\-\/.]+\.e?rb):(?<line>\d+):in\s`(?<method>.+)'/x.freeze
+      LOCATION_REGEXP = /^(?<file>[\w_\-\/.]+\.e?rb):(?<line>\d+):in\s`(?:block\sin\s)?(?<method>.+)'/x.freeze
 
       EXAMPLES_COUNT = 3
 

--- a/lib/jiminy/recording/n_plus_one.rb
+++ b/lib/jiminy/recording/n_plus_one.rb
@@ -5,21 +5,19 @@ module Jiminy
     class NPlusOne
       attr_reader :file, :location
 
-      LOCATION_MATCHER = /(?<file>.+\.rb):
-        (?<line>\d+):in\s`
-        (?:block\sin\s)?
-        (?<method_name>.+)'
-      /x.freeze
+      LOCATION_REGEXP = /^(?<file>[\w_\-\/.]+\.e?rb):(?<line>\d+):in\s`(?<method>.+)'/x.freeze
 
       EXAMPLES_COUNT = 3
 
       def initialize(location:, queries: [])
         @location = location.to_s.strip
         @queries = queries
-        match = location.match(LOCATION_MATCHER)
-        @line = match[:line]
-        @method_name = match[:method_name]
-        @file = match[:file]
+        match_result = location.match(LOCATION_REGEXP)
+
+        @file = match_result[:file]
+        @line = match_result[:line]
+        @method_name = match_result[:method]
+
         freeze
       end
 

--- a/spec/jiminy/recording/n_plus_one_spec.rb
+++ b/spec/jiminy/recording/n_plus_one_spec.rb
@@ -1,0 +1,44 @@
+require "spec_helper"
+require "jiminy/recording/n_plus_one"
+
+RSpec.describe Jiminy::Recording::NPlusOne do
+  context "when location is an RHTML template" do
+    describe "#to_h" do
+      it "contains the file, line, and details" do
+        location_string = "app/views/users/_user.html.erb:1:in `_app_views_users__user_html_erb__2366356888272897519_876440'"
+        n_plus_one = Jiminy::Recording::NPlusOne.new(location: location_string)
+
+        hash = n_plus_one.to_h
+
+        expect(hash).to eql({
+          location_string => {
+            "examples" => [],
+            "file" => "app/views/users/_user.html.erb",
+            "line"=> "1",
+            "method" => "_app_views_users__user_html_erb__2366356888272897519_876440",
+          }
+        })
+      end
+    end
+  end
+
+  context "when location is a Ruby file" do
+    describe "#to_h" do
+      it "contains the file, line, and details" do
+        location_string = "app/models/admins/user.rb:13:in `map'"
+        n_plus_one = Jiminy::Recording::NPlusOne.new(location: location_string)
+
+        hash = n_plus_one.to_h
+
+        expect(hash).to eql({
+          location_string => {
+            "examples" => [],
+            "file" => "app/models/admins/user.rb",
+            "line"=> "13",
+            "method" => "map",
+          }
+        })
+      end
+    end
+  end
+end

--- a/spec/jiminy/recording/n_plus_one_spec.rb
+++ b/spec/jiminy/recording/n_plus_one_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe Jiminy::Recording::NPlusOne do
           location_string => {
             "examples" => [],
             "file" => "app/views/users/_user.html.erb",
-            "line"=> "1",
-            "method" => "_app_views_users__user_html_erb__2366356888272897519_876440",
+            "line" => "1",
+            "method" => "_app_views_users__user_html_erb__2366356888272897519_876440"
           }
         })
       end
@@ -34,8 +34,8 @@ RSpec.describe Jiminy::Recording::NPlusOne do
           location_string => {
             "examples" => [],
             "file" => "app/models/admins/user.rb",
-            "line"=> "13",
-            "method" => "map",
+            "line" => "13",
+            "method" => "map"
           }
         })
       end


### PR DESCRIPTION
Supports n+1 instances reported by Prosopite that have .erb in the file extension. 

These tend not to give helpful information about the method name, so we might want to rethink how we represent an n+1 instance.