### PR TITLE
Don't post comment if errors are blank

### DIFF
--- a/lib/jiminy/reporting.rb
+++ b/lib/jiminy/reporting.rb
@@ -21,6 +21,9 @@ module Jiminy
       comment_content = yaml_files.map do |yaml_file|
         YAMLFileCommentPresenter.new(source_filepath: yaml_file, pr_number: options[:pr_number]).to_s
       end.join(LINE_SEPARATOR)
+
+      return if comment_content.strip.empty?
+
       if options[:dry_run]
         Reporters::DryRunReporter.new(header: COMMENT_HEADER, body: comment_content).report!
       else


### PR DESCRIPTION
When YAML files are provided, but no matching instances are detected, don't post a comment