### PR TITLE
Load RSpec module automatically in test environment

### DIFF
--- a/lib/jiminy.rb
+++ b/lib/jiminy.rb
@@ -3,6 +3,7 @@
 require_relative "jiminy/version"
 require_relative "jiminy/setup"
 require_relative "jiminy/recording" if defined?(Rails)
+require_relative "jiminy/rspec" if ENV["RAILS_ENV"] == "test"
 
 module Jiminy
   module_function

--- a/lib/jiminy.rb
+++ b/lib/jiminy.rb
@@ -3,7 +3,7 @@
 require_relative "jiminy/version"
 require_relative "jiminy/setup"
 require_relative "jiminy/recording" if defined?(Rails)
-require_relative "jiminy/rspec" if ENV["RAILS_ENV"] == "test"
+require_relative "jiminy/rspec" if defined?(Rspec) && ENV["RAILS_ENV"] == "test"
 
 module Jiminy
   module_function

--- a/lib/jiminy/recording/prosopite_ext/tmp_file_recorder.rb
+++ b/lib/jiminy/recording/prosopite_ext/tmp_file_recorder.rb
@@ -6,6 +6,7 @@ module Jiminy
       class TmpFileRecorder
         require_relative "../n_plus_one"
 
+        # rubocop:disable Metrics/AbcSize
         def record(location:, queries:)
           yaml_content = File.read(Jiminy.config.temp_file_location)
           array = YAML.safe_load(yaml_content)
@@ -24,6 +25,7 @@ module Jiminy
           array << n_plus_one.to_h
           File.write(Jiminy.config.temp_file_location, array.to_yaml)
         end
+        # rubocop:enable Metrics/AbcSize
 
         private
 


### PR DESCRIPTION
Instead of expecting gem users to extend their spec `rails_helper.rb` file, automatically load the RSpec module if the gem is detected and the Rails env is `"test"`