### PR TITLE
Replace logger debug strings with blocks

### DIFF
--- a/lib/jiminy/recording/prosopite_ext/tmp_file_recorder.rb
+++ b/lib/jiminy/recording/prosopite_ext/tmp_file_recorder.rb
@@ -6,24 +6,26 @@ module Jiminy
       class TmpFileRecorder
         require_relative "../n_plus_one"
 
+        # rubocop:disable Metrics/AbcSize
         def record(location:, queries:)
           yaml_content = File.read(Jiminy.config.temp_file_location)
           array = YAML.safe_load(yaml_content)
           n_plus_one = NPlusOne.new(location: location, queries: queries)
 
           if filepath_ignored?(n_plus_one.file)
-            Jiminy.logger.debug("Ignoring n+1 instance #{n_plus_one}")
+            Jiminy.logger.debug { "Ignoring n+1 instance #{n_plus_one}" }
             return
           end
 
           if location_in_array?(location, array)
-            Jiminy.logger.debug("Already reported n+1 instance #{n_plus_one}")
+            Jiminy.logger.debug { "Already reported n+1 instance #{n_plus_one}" }
             return
           end
 
           array << n_plus_one.to_h
           File.write(Jiminy.config.temp_file_location, array.to_yaml)
         end
+        # rubocop:enable Metrics/AbcSize
 
         private
 

--- a/lib/jiminy/reporting/ci_providers/circle_ci/api_request.rb
+++ b/lib/jiminy/reporting/ci_providers/circle_ci/api_request.rb
@@ -14,7 +14,7 @@ module Jiminy
           end
 
           def perform!
-            Jiminy.logger.debug("API request: #@url")
+            Jiminy.logger.debug { "API request: #@url" }
             response
           end
 


### PR DESCRIPTION
When calling `logger.debug`, use blocks instead of passing string instances. This is more efficient when the logger is not defined, or the logger level is higher than `DEBUG`, as the String interpolation is never executed.