### PR TITLE
Refactor error codes to return 0 more often

### DIFF
--- a/lib/jiminy/cli.rb
+++ b/lib/jiminy/cli.rb
@@ -4,6 +4,8 @@ module Jiminy
   require "thor"
   class CLI < Thor
     require "jiminy/reporting/ci_providers/circle_ci"
+    require "jiminy/cli/exit_codes"
+
     include Thor::Actions
     include Jiminy::Reporting::CIProviders
 
@@ -41,8 +43,7 @@ module Jiminy
         pr_number: options[:pr_number],
         dry_run: options[:dry_run])
 
-      $stdout.puts "Reported N+1s successfully"
-      exit(0)
+      finish(ExitCodes::Success)
     end
 
     desc "Install Jiminy", "Installs jiminy configuration files in your app"
@@ -53,6 +54,17 @@ module Jiminy
     # rubocop:disable Metrics/BlockLength
     no_tasks do
       attr_accessor :start_time
+
+      def finish(exit_code, *args, **kwargs)
+        e = exit_code.is_a?(ExitCodes::Base) ? exit_code : exit_code.new(*args, **kwargs)
+        if e.value == 0
+          $stdout.puts e
+          exit(e.value)
+        else
+          $stderr.puts e
+          abort(e.value)
+        end
+      end
 
       def poll_interval
         options[:poll_interval] || POLL_INTERVAL_SECONDS
@@ -80,7 +92,7 @@ module Jiminy
 
       def pipeline
         @_pipeline ||= CircleCI::Pipeline.find_by_revision(git_revision: git_revision, pr_number: pr_number) or
-          abort("No such Pipeline with commit SHA #{git_revision}")
+                         finish(ExitCodes::PipelineNotFound.new(git_revision: git_revision))
       end
 
       def missing_options
@@ -95,14 +107,14 @@ module Jiminy
         @_workflow ||= begin
           result = CircleCI::Workflow.find(pipeline_id: pipeline.id, workflow_name: Jiminy.config.ci_workflow_name)
           if result.nil?
-            abort("Unable to find workflow called '#{Jiminy.config.ci_workflow_name}' in Pipeline #{pipeline.id}")
+            finish(ExitCodes::WorkflowNotFound.new(workflow_name: Jiminy.config.ci_workflow_name, pipeline_id: pipeline.id))
           end
 
           if result.not_run? || result.running?
             $stdout.puts "Workflow still running..."
             raise(WorkflowStillRunningError)
           end
-          abort("Workflow #{result.status}—aborting...") unless result.success?
+          finish(ExitCodes::WorkflowNotSuccess.new(status: result.status)) unless result.success?
 
           result
         rescue WorkflowStillRunningError
@@ -110,7 +122,7 @@ module Jiminy
           $stdout.puts "Retrying..."
           retry unless timed_out?
 
-          abort("Process timed out after #{Time.now - start_time} seconds")
+          finish(ExitCodes::ProcessTimeout.new(start_time: start_time))
         end
       end
       # rubocop:enable Metrics/AbcSize

--- a/lib/jiminy/cli.rb
+++ b/lib/jiminy/cli.rb
@@ -115,8 +115,9 @@ module Jiminy
             $stdout.puts "Workflow still running..."
             raise(WorkflowStillRunningError)
           end
-          finish(ExitCodes::WorkflowNotSuccess,
-            status: result.status) unless result.success?
+          unless result.success?
+            finish(ExitCodes::WorkflowNotSuccess, status: result.status)
+          end
 
           result
         rescue WorkflowStillRunningError

--- a/lib/jiminy/cli.rb
+++ b/lib/jiminy/cli.rb
@@ -61,7 +61,7 @@ module Jiminy
           $stdout.puts e
           exit(e.value)
         else
-          $stderr.puts e
+          warn e
           abort(e.value)
         end
       end
@@ -92,7 +92,7 @@ module Jiminy
 
       def pipeline
         @_pipeline ||= CircleCI::Pipeline.find_by_revision(git_revision: git_revision, pr_number: pr_number) or
-                         finish(ExitCodes::PipelineNotFound.new(git_revision: git_revision))
+          finish(ExitCodes::PipelineNotFound.new(git_revision: git_revision))
       end
 
       def missing_options
@@ -107,7 +107,8 @@ module Jiminy
         @_workflow ||= begin
           result = CircleCI::Workflow.find(pipeline_id: pipeline.id, workflow_name: Jiminy.config.ci_workflow_name)
           if result.nil?
-            finish(ExitCodes::WorkflowNotFound.new(workflow_name: Jiminy.config.ci_workflow_name, pipeline_id: pipeline.id))
+            finish(ExitCodes::WorkflowNotFound.new(workflow_name: Jiminy.config.ci_workflow_name,
+              pipeline_id: pipeline.id))
           end
 
           if result.not_run? || result.running?

--- a/lib/jiminy/cli.rb
+++ b/lib/jiminy/cli.rb
@@ -58,12 +58,11 @@ module Jiminy
       def finish(exit_code_klass, *args, **kwargs)
         exit_code = exit_code_klass.new(*args, **kwargs)
         if exit_code.value == 0
-          $stdout.puts exit_code
-          exit(exit_code.value)
+          puts exit_code
         else
           warn exit_code
-          abort(exit_code.value)
         end
+        exit(exit_code.value)
       end
 
       def poll_interval

--- a/lib/jiminy/cli/exit_codes.rb
+++ b/lib/jiminy/cli/exit_codes.rb
@@ -4,10 +4,3 @@ require_relative "exit_codes/process_timeout"
 require_relative "exit_codes/success"
 require_relative "exit_codes/workflow_not_found"
 require_relative "exit_codes/workflow_not_success"
-
-module Jiminy
-  class CLI
-    module ExitCodes
-    end
-  end
-end

--- a/lib/jiminy/cli/exit_codes.rb
+++ b/lib/jiminy/cli/exit_codes.rb
@@ -1,0 +1,13 @@
+require_relative "exit_codes/base"
+require_relative "exit_codes/pipeline_not_found"
+require_relative "exit_codes/process_timeout"
+require_relative "exit_codes/success"
+require_relative "exit_codes/workflow_not_found"
+require_relative "exit_codes/workflow_not_success"
+
+module Jiminy
+  class CLI
+    module ExitCodes
+    end
+  end
+end

--- a/lib/jiminy/cli/exit_codes/base.rb
+++ b/lib/jiminy/cli/exit_codes/base.rb
@@ -1,0 +1,11 @@
+module Jiminy
+  class CLI
+    module ExitCodes
+      Base = Struct.new(:message, :value) do
+        def to_s
+          message
+        end
+      end
+    end
+  end
+end

--- a/lib/jiminy/cli/exit_codes/pipeline_not_found.rb
+++ b/lib/jiminy/cli/exit_codes/pipeline_not_found.rb
@@ -1,0 +1,11 @@
+module Jiminy
+  class CLI
+    module ExitCodes
+      class PipelineNotFound < Base
+        def initialize(git_revision:)
+          super("No such Pipeline with commit SHA #{git_revision}", 1)
+        end
+      end
+    end
+  end
+end

--- a/lib/jiminy/cli/exit_codes/process_timeout.rb
+++ b/lib/jiminy/cli/exit_codes/process_timeout.rb
@@ -1,0 +1,11 @@
+module Jiminy
+  class CLI
+    module ExitCodes
+      class ProcessTimeout < Base
+        def initialize(start_time:)
+          super("Process timed out after #{Time.now - start_time} seconds", 1)
+        end
+      end
+    end
+  end
+end

--- a/lib/jiminy/cli/exit_codes/success.rb
+++ b/lib/jiminy/cli/exit_codes/success.rb
@@ -1,0 +1,11 @@
+module Jiminy
+  class CLI
+    module ExitCodes
+      class Success < Base
+        def initialize
+          super("Reported N+1s successfully", 0)
+        end
+      end
+    end
+  end
+end

--- a/lib/jiminy/cli/exit_codes/workflow_not_found.rb
+++ b/lib/jiminy/cli/exit_codes/workflow_not_found.rb
@@ -1,0 +1,11 @@
+module Jiminy
+  class CLI
+    module ExitCodes
+      class WorkflowNotFound < Base
+        def initialize(pipeline_id:, workflow_name:)
+          super("Unable to find workflow called '#{workflow_name}' in Pipeline #{pipeline_id}", 1)
+        end
+      end
+    end
+  end
+end

--- a/lib/jiminy/cli/exit_codes/workflow_not_success.rb
+++ b/lib/jiminy/cli/exit_codes/workflow_not_success.rb
@@ -1,0 +1,11 @@
+module Jiminy
+  class CLI
+    module ExitCodes
+      class WorkflowNotSuccess < Base
+        def initialize(status:)
+          super("Workflow #{status}—aborting...", 0)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
We don't want to report Jiminy as having failed if the test suite fails. 

This PR adds objects for the various ExitCodes.

| Class      | Exit code | Description   |
| :---        |    :----:   |          ---: |
| Pipeline not found | 1       |  Couldn't find this Pipeline on CircleCI   |
| Process timed out | 1       |  CircleCI job didn't pass successfully in time  |
| Success | 0       |  All good 😃 👍  |
| Workflow not found | 1       |  Couldn't find this Workflow on CircleCI   |
| Workflow not success | 0       |  Tests failed, but pass jiminy anyway   |
