### PR TITLE
Add support for jbuilder templates

### DIFF
--- a/lib/jiminy/recording/n_plus_one.rb
+++ b/lib/jiminy/recording/n_plus_one.rb
@@ -5,7 +5,10 @@ module Jiminy
     class NPlusOne
       attr_reader :file, :location
 
-      LOCATION_REGEXP = /^(?<file>[\w_\-\/.]+\.e?rb):(?<line>\d+):in\s`(?:block\sin\s)?(?<method>.+)'/x.freeze
+      LOCATION_REGEXP = %r{^
+        (?<file>[\w_\-/.]+\.(?:erb|rb|jbuilder)):
+        (?<line>\d+):in\s`(?:block\sin\s)?
+        (?<method>[^']+)'?}x.freeze
 
       EXAMPLES_COUNT = 3
 

--- a/spec/jiminy/recording/n_plus_one_spec.rb
+++ b/spec/jiminy/recording/n_plus_one_spec.rb
@@ -41,4 +41,23 @@ RSpec.describe Jiminy::Recording::NPlusOne do
       end
     end
   end
+  context "when location is in a jbuilder file" do
+    describe "#to_h" do
+      it "contains the file, line, and details" do
+        location_string = "app/views/widgets/_widget.json.jbuilder:3:in `block in _app_views_widgets__widget_json_jbuilder___243700433639123'"
+        n_plus_one = Jiminy::Recording::NPlusOne.new(location: location_string)
+
+        hash = n_plus_one.to_h
+
+        expect(hash).to eql({
+          location_string => {
+            "examples" => [],
+            "file" => "app/views/widgets/_widget.json.jbuilder",
+            "line" => "3",
+            "method" => "_app_views_widgets__widget_json_jbuilder___243700433639123"
+          }
+        })
+      end
+    end
+  end
 end


### PR DESCRIPTION
Add support for n+1s that are detected in files with extension `.jbuilder`.
