### PR TITLE
Fix typo in requires when checking for RSpec

### DIFF
--- a/lib/jiminy.rb
+++ b/lib/jiminy.rb
@@ -3,7 +3,7 @@
 require_relative "jiminy/version"
 require_relative "jiminy/setup"
 require_relative "jiminy/recording" if defined?(Rails)
-require_relative "jiminy/rspec" if defined?(Rspec) && ENV["RAILS_ENV"] == "test"
+require_relative "jiminy/rspec" if defined?(RSpec) && ENV["RAILS_ENV"] == "test"
 
 module Jiminy
   module_function


### PR DESCRIPTION
## What 

Fixes bug preventing spec helper from loading properly when RSpec is installed.

## Why 

This is breaking, causing a bad UX for developers trying to implement Jiminy

## How 

Rewrite `Rspec` to `RSpec` uppercase "S" to match the RSpec gem naming.