### PR TITLE
Include TestControllerConcern in ActionController::Api

### DIFF
--- a/lib/jiminy/recording/minitest.rb
+++ b/lib/jiminy/recording/minitest.rb
@@ -14,6 +14,7 @@ module Jiminy
         super
         Prosopite.tmp_file = true
         ActionController::Base.include(Jiminy::Recording::TestControllerConcern)
+        ActionController::Api.include(Jiminy::Recording::TestControllerConcern)
       end
 
       def after_teardown

--- a/lib/jiminy/recording/rspec.rb
+++ b/lib/jiminy/recording/rspec.rb
@@ -13,6 +13,7 @@ module Jiminy
       def wrap_rspec_example(example)
         Prosopite.tmp_file = true
         ActionController::Base.include(Jiminy::Recording::TestControllerConcern)
+        ActionController::Api.include(Jiminy::Recording::TestControllerConcern)
         example.run
         Prosopite.tmp_file = false
       end


### PR DESCRIPTION
We add this module to ActionController::Base but if someone starts a Rails app in --api mode it has a different base controller class

We can't add this to a shared parent (Metal) because that class does not implement around_action - which is included in each of Base and Api. So additionally including the module in Api feels reasonable

https://github.com/rails/rails/blob/e525dd24900e3529d0e775d00bebc888fda6ce02/actionpack/lib/abstract_controller/callbacks.rb#L198 https://github.com/rails/rails/blob/main/actionpack/lib/action_controller/api.rb